### PR TITLE
System object __str__ fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 dist
 *tab
 *ods
+system_test.py

--- a/T5_worldgen/system.py
+++ b/T5_worldgen/system.py
@@ -96,7 +96,7 @@ class System(object):
             str(self.pbg),
             self.num_worlds,
             self.allegiance,
-            self.stellar)
+            self.stellar.display())
 
     def determine_nobility(self):
         '''Determine noble representation'''


### PR DESCRIPTION
I was getting this error when playing around with the System() object and printing it out as it has a __str__() method.

TypeError: unsupported format string passed to Primary.__format__

The self.stellar member is a Primary() object which doesn't have a __str__ method, so we need to call Primary.display() to get a string representation, the same as the System.display() method does.